### PR TITLE
match html title to source page

### DIFF
--- a/static/template.html
+++ b/static/template.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Readable</title>
+    <title>{{title}}</title>
     <style>
       /* Copyright 2015 Ruud van Asseldonk
        * Adapted from the original by Matthias Endler


### PR DESCRIPTION
Currently, the HTML page title for any Readable page is just `Readable`. If you have multiple Readable tabs open it's hard to distinguish between them. Since the template already makes use of the source page title, it's super easy to use it for the HTML title as well.

Thanks for building this, btw! I also use Firefox's Reader Mode a lot, but I agree that it's not the prettiest and I'm a sucker for a pretty web page :) 