### PR TITLE
use prebuilt Shuttle binary in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,21 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: shuttle-hq/deploy-action@main
-        with:
-          deploy-key: ${{ secrets.SHUTTLE_DEPLOY_KEY }}
+      - name: Install Shuttle
+        run: |
+          set -e
+          RELEASE=$(curl -fsSL https://api.github.com/repos/jfmontanaro/cargo-shuttle-builds/releases/latest)
+          URL=$(jq -r <<<$RELEASE '.assets[] | select(.name == "cargo-shuttle_x86_64-unknown-linux-gnu") | .browser_download_url')
+          curl -fsSL $URL > cargo-shuttle
+          chmod +x cargo-shuttle
+          mv cargo-shuttle ~/.cargo/bin
+
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Deploy to Shuttle
+        run: |
+          set -e
+          cargo shuttle login --api-key ${{ secrets.SHUTTLE_DEPLOY_KEY }}
+          # the official Shuttle action strips out the database uri, we might as well do the same
+          cargo shuttle deploy --name readable-test | awk '!/Database URI.*?$/'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
           set -e
           cargo shuttle login --api-key ${{ secrets.SHUTTLE_DEPLOY_KEY }}
           # the official Shuttle action strips out the database uri, we might as well do the same
-          cargo shuttle deploy --name readable-test | awk '!/Database URI.*?$/'
+          cargo shuttle deploy | awk '!/Database URI.*?$/'


### PR DESCRIPTION
The vast majority of the time in CI is spent compiling `cargo-shuttle` itself, along with its >500 dependencies. We can save a lot of time by using a prebuilt binary instead.

The official shuttle-hq/deploy-action tries to do this by using `cargo-quickinstall`, but unfortunately it looks like `cargo-quickinstall` doesn't have an up-to-date build of Shuttle so it falls back to building it from scratch. To replace this I set up a quick [nightly build](https://github.com/jfmontanaro/cargo-shuttle-builds) of Shuttle from which we can pull the built binary.

I was going to use [sccache](https://github.com/mozilla/sccache) to try and speed things up even further, but Shuttle already seems to include some kind of magic incremental-compilation-restoring functionality that renders sccache both unusable (or at least, not easily usable) and unnecessary.

Builds still take a couple of minutes, but hey, at least it's not 10.