### PR TITLE
Changed fallback to satisfy trait bounds in self hosting deploy

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
                 )
             }),
         )
-        .fallback(get(readable));
+        .fallback(readable);
     let addr = SocketAddr::from(([127, 0, 0, 1], 8000));
     axum::Server::bind(&addr)
         .serve(router.into_make_service())


### PR DESCRIPTION
+ Changed fallback to satisfy trait bounds

On a local deploy attempt, line 35 didn't satisfy trait bounds as it returned `get(readable)` instead of just readable which seems to be different from the routing in lib.rs, so I changed it to reflect that and it now seems to build correctly.