### PR TITLE
Add viewport meta for mobile devices

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub fn index() -> Html<String> {
     render(
         "Readable.",
         "Readable",
-        "A simple web service to extract the main content from an article<br /> and format it for <i>reading</i>.
+        "A simple web service to extract the main content from an article and format it for <i>reading</i>.
         Source code <a href=\"https://github.com/mre/readable\">here</a>.
         ",
         include_str!("../static/index.html"),

--- a/static/template.html
+++ b/static/template.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{{page_title}}</title>
     <style>
       /* Copyright 2015 Ruud van Asseldonk
@@ -52,7 +53,7 @@
       }
 
       html {
-        font-size: 17px;
+        font-size: 18px;
       }
 
       body {
@@ -116,6 +117,7 @@
         padding-top: 0.5em;
         padding-bottom: 0.9em;
         margin-bottom: 0;
+        max-width: 26em;
       }
 
       header > p > a {


### PR DESCRIPTION
Should fix #3. Comparison of before and after on a Pixel 4a:

![comparison](https://user-images.githubusercontent.com/10636404/212203203-f3754b2c-710e-439c-89ea-098f228cacef.jpg)

Apparently, for backwards compatibility, mobile devices will automatically render pages at a wide "virtual" resolution and then scale them down to fit within the visible space, unless you tell them not to. MDN explains [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag).

TL;DR - `<meta name="viewport" content="width=device-width, initial-scale=1" />` fixes everything. Who knew!

I also replaced the hard-coded linebreak in the subheading with a `max-width` property, so that it would shrink nicely on narrow screens.